### PR TITLE
Add "closed" class to postbox

### DIFF
--- a/plugin-ui.php
+++ b/plugin-ui.php
@@ -112,7 +112,7 @@
 			$eid++;
 		?>
 		<div id="metabox-<?php echo $eid; ?>" class="meta-box">
-		<div class="shortcode-description postbox">
+		<div class="shortcode-description postbox closed">
 			<h3 class="hndle"><span>3rd-Party Service: <?php echo esc_attr($entity['name'])?></span></h3>
 			
 			<div class="description-body inside">


### PR DESCRIPTION
An issue seems to occur on the newer versions of WordPress. The issue is that when you click on `<h3>` an AJAX request is made to the server which returned 403 code and postbox wouldn't expand at all. Adding **closed** class fixes this issue (#116 seems to be related.)